### PR TITLE
Fix bug where eol comment after nil value is misplaced

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -219,7 +219,7 @@ func (e *encoder) itemsv(tag string, in reflect.Value) {
 			// If the value is a primitive value (eg. string, int), an end-of-line comment should follow the value,
 			// else it should follow the key. Note that empty end-of-line comments are ignored.
 			switch item.Value.(type) {
-			case string, int, bool:
+			case string, int, bool, nil:
 				e.marshal("", reflect.ValueOf(item.Value))
 				if len(item.Comment) > 0 {
 					e.eolcommentv([]byte(item.Comment))


### PR DESCRIPTION
The input
```
creationTimestamp: null # Creation timestamp null
```
was marshaled into
```
creationTimestamp: # Creation timestamp null null
```
(The null value gets placed after the comment). This PR fixes this so the output is the same as the input.