### PR TITLE
Support no line breaks during yaml Marshaling

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -41,6 +41,7 @@ func newEncoder() *encoder {
 	yaml_emitter_initialize(&e.emitter)
 	yaml_emitter_set_output_string(&e.emitter, &e.out)
 	yaml_emitter_set_unicode(&e.emitter, true)
+	yaml_emitter_set_width(&e.emitter, -1)
 	return e
 }
 
@@ -49,6 +50,7 @@ func newEncoderWithWriter(w io.Writer) *encoder {
 	yaml_emitter_initialize(&e.emitter)
 	yaml_emitter_set_output_writer(&e.emitter, w)
 	yaml_emitter_set_unicode(&e.emitter, true)
+	yaml_emitter_set_width(&e.emitter, -1)
 	return e
 }
 
@@ -462,8 +464,4 @@ func (e *encoder) emitScalar(value, anchor, tag string, style yaml_scalar_style_
 	implicit := tag == ""
 	e.must(yaml_scalar_event_initialize(&e.event, []byte(anchor), []byte(tag), []byte(value), implicit, implicit, style))
 	e.emit()
-}
-
-func (e *encoder) setWidth(width int) {
-	yaml_emitter_set_width(&e.emitter, width)
 }

--- a/encode.go
+++ b/encode.go
@@ -463,3 +463,7 @@ func (e *encoder) emitScalar(value, anchor, tag string, style yaml_scalar_style_
 	e.must(yaml_scalar_event_initialize(&e.event, []byte(anchor), []byte(tag), []byte(value), implicit, implicit, style))
 	e.emit()
 }
+
+func (e *encoder) setWidth(width int) {
+	yaml_emitter_set_width(&e.emitter, width)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module "github.com/Shopify/yaml"
+module github.com/Shopify/yaml
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,1 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,1 +1,2 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/yaml.go
+++ b/yaml.go
@@ -218,6 +218,7 @@ func unmarshal(in []byte, out interface{}, strict bool, parse_comments bool) (er
 func Marshal(in interface{}) (out []byte, err error) {
 	defer handleErr(&err)
 	e := newEncoder()
+	e.SetLineWidth(-1)
 	defer e.destroy()
 	e.marshalDoc("", reflect.ValueOf(in))
 	e.finish()
@@ -237,6 +238,13 @@ func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{
 		encoder: newEncoderWithWriter(w),
 	}
+}
+
+// SetLineWidth sets the preferred line width.
+// To disable long line breaks set width lower than zero.
+// By default, line width is set to 80.
+func (e *Encoder) SetLineWidth(width int) {
+	e.encoder.setWidth(width)
 }
 
 // Encode writes the YAML encoding of v to the stream.

--- a/yaml.go
+++ b/yaml.go
@@ -218,7 +218,6 @@ func unmarshal(in []byte, out interface{}, strict bool, parse_comments bool) (er
 func Marshal(in interface{}) (out []byte, err error) {
 	defer handleErr(&err)
 	e := newEncoder()
-	e.SetLineWidth(-1)
 	defer e.destroy()
 	e.marshalDoc("", reflect.ValueOf(in))
 	e.finish()
@@ -238,13 +237,6 @@ func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{
 		encoder: newEncoderWithWriter(w),
 	}
-}
-
-// SetLineWidth sets the preferred line width.
-// To disable long line breaks set width lower than zero.
-// By default, line width is set to 80.
-func (e *Encoder) SetLineWidth(width int) {
-	e.encoder.setWidth(width)
 }
 
 // Encode writes the YAML encoding of v to the stream.


### PR DESCRIPTION
This PR adds support to override 80 char per line limit set during yaml Marshaling

https://github.com/Shopify/kubeaudit/blob/61d5cd825e6442d7c3dc90821932c3c98bd00e59/cmd/autofix_util.go#L289

In kubeaudit when Marshal will be called, we won't break lines anymore :) 